### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 		<tools.org.postgresql.version>9.2-1003-jdbc4</tools.org.postgresql.version>
 		<tools.javax.servlet.version>2.5</tools.javax.servlet.version>
 		<tools.commons-logging.version>1.0.4</tools.commons-logging.version>
-		<tools.commons-collections.version>3.2.1</tools.commons-collections.version>
+		<tools.commons-collections.version>3.2.2</tools.commons-collections.version>
 		<tools.commons-beanutils.version>1.8.3</tools.commons-beanutils.version>
 		<tools.commons-pool.version>1.5.4</tools.commons-pool.version>
 		<tools.commons-lang.version>2.4</tools.commons-lang.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
